### PR TITLE
Feat/print history

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -18,7 +18,11 @@ pub struct Args {
     #[arg(long, help = "End date for the commits in YYYY-MM-DD format")]
     pub end: Option<String>,
 
-    #[arg(short = 's', long = "show-history", help = "Show updated commit history after rewriting")]
+    #[arg(
+        short = 's',
+        long = "show-history",
+        help = "Show updated commit history after rewriting"
+    )]
     pub show_history: bool,
 }
 

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -63,7 +63,7 @@ pub fn rewrite_commits(args: &Args, timestamps: Vec<NaiveDateTime>) -> Result<()
             new_head.to_string().cyan()
         );
         if args.show_history {
-            print_updated_history(&args)?;
+            print_updated_history(args)?;
         }
     }
 
@@ -72,15 +72,15 @@ pub fn rewrite_commits(args: &Args, timestamps: Vec<NaiveDateTime>) -> Result<()
 
 pub fn print_updated_history(args: &Args) -> Result<()> {
     let repo = Repository::open(args.repo_path.as_ref().unwrap())?;
-    
+
     let mut revwalk = repo.revwalk()?;
     revwalk.push_head()?;
     revwalk.set_sorting(Sort::TOPOLOGICAL | Sort::TIME)?;
-    
+
     // Collect all commits first to calculate statistics
     let mut commits = Vec::new();
     let mut timestamps = Vec::new();
-    
+
     for oid_result in revwalk {
         let oid = oid_result?;
         let commit = repo.find_commit(oid)?;
@@ -88,52 +88,77 @@ pub fn print_updated_history(args: &Args) -> Result<()> {
         let datetime = chrono::DateTime::from_timestamp(timestamp.seconds(), 0)
             .unwrap_or_default()
             .naive_utc();
-        
+
         commits.push((oid, commit));
         timestamps.push(datetime);
     }
-    
+
     // Calculate statistics
     let total_commits = commits.len();
     let (earliest_date, latest_date) = if !timestamps.is_empty() {
         let mut sorted_timestamps = timestamps.clone();
         sorted_timestamps.sort();
-        (sorted_timestamps[0], sorted_timestamps[sorted_timestamps.len() - 1])
+        (
+            sorted_timestamps[0],
+            sorted_timestamps[sorted_timestamps.len() - 1],
+        )
     } else {
         return Ok(());
     };
-    
+
     let date_span = latest_date.signed_duration_since(earliest_date).num_days();
-    let unique_authors: std::collections::HashSet<String> = commits.iter()
+    let unique_authors: std::collections::HashSet<String> = commits
+        .iter()
         .map(|(_, commit)| commit.author().name().unwrap_or("Unknown").to_string())
         .collect();
-    
+
     // Print summary
     println!("\n{}", "Updated Commit History Summary:".bold().green());
     println!("{}", "-".repeat(60).cyan());
-    println!("{}: {}", "Total Commits".bold(), total_commits.to_string().yellow());
-    println!("{}: {} days", "Date Span".bold(), date_span.to_string().yellow());
-    println!("{}: {} to {}", 
-        "Date Range".bold(), 
+    println!(
+        "{}: {}",
+        "Total Commits".bold(),
+        total_commits.to_string().yellow()
+    );
+    println!(
+        "{}: {} days",
+        "Date Span".bold(),
+        date_span.to_string().yellow()
+    );
+    println!(
+        "{}: {} to {}",
+        "Date Range".bold(),
         earliest_date.format("%Y-%m-%d %H:%M:%S").to_string().blue(),
         latest_date.format("%Y-%m-%d %H:%M:%S").to_string().blue()
     );
-    println!("{}: {}", "Unique Authors".bold(), unique_authors.len().to_string().yellow());
+    println!(
+        "{}: {}",
+        "Unique Authors".bold(),
+        unique_authors.len().to_string().yellow()
+    );
     if unique_authors.len() <= 5 {
-        println!("{}: {}", "Authors".bold(), 
-            unique_authors.iter().cloned().collect::<Vec<_>>().join(", ").magenta());
+        println!(
+            "{}: {}",
+            "Authors".bold(),
+            unique_authors
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ")
+                .magenta()
+        );
     }
     println!("{}", "=".repeat(60).cyan());
-    
+
     // Print detailed commit history
     println!("\n{}", "Detailed Commit History:".bold().green());
     println!("{}", "-".repeat(60).cyan());
-    
+
     for (i, (oid, commit)) in commits.iter().enumerate() {
         let short_hash = &oid.to_string()[..8];
         let message = commit.message().unwrap_or("(no message)");
         let author = commit.author();
-        
+
         println!(
             "{} {} {} {}",
             short_hash.yellow().bold(),
@@ -142,8 +167,8 @@ pub fn print_updated_history(args: &Args) -> Result<()> {
             message.lines().next().unwrap_or("").white()
         );
     }
-    
+
     println!("{}", "=".repeat(60).cyan());
-    
+
     Ok(())
 }


### PR DESCRIPTION
This pull request introduces a new feature to display an updated commit history summary and detailed commit information after rewriting commits. The most important changes include adding a new command-line argument to enable this feature and implementing the logic to calculate and display commit history statistics.

### New Feature: Show Updated Commit History

* **Added a new command-line argument**: Introduced the `--show-history` (`-s`) flag in the `Args` struct to allow users to toggle the display of the updated commit history summary after rewriting commits. (`src/args.rs`, [src/args.rsR20-R22](diffhunk://#diff-c3fd08257cd326dfa1c2a3c0a69e6b842f194950ac32e7b2c6e2750f52d1765fR20-R22))

* **Implemented commit history display logic**:
  - Added a new function `print_updated_history` to calculate and display statistics such as total commits, date span, date range, and unique authors.
  - Enhanced the `rewrite_commits` function to invoke `print_updated_history` when the `--show-history` flag is set. (`src/rewrite.rs`, [src/rewrite.rsR65-R146](diffhunk://#diff-a5d25986d68ac03b6e1f19f7f0275004f5642e2ca83c5d176b8bf9b2d38bb239R65-R146))