### PR TITLE
chore: added short forms for more args

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -9,13 +9,13 @@ pub struct Args {
     #[arg(long, help = "Email associated with the commits")]
     pub email: Option<String>,
 
-    #[arg(long, help = "Name associated with the commits")]
+    #[arg(short = 'n', long = "name", help = "Name associated with the commits")]
     pub name: Option<String>,
 
-    #[arg(long, help = "Start date for the commits in YYYY-MM-DD format")]
+    #[arg(short = 'b', long = "begin", help = "Start date for the commits in YYYY-MM-DD format")]
     pub start: Option<String>,
 
-    #[arg(long, help = "End date for the commits in YYYY-MM-DD format")]
+    #[arg(short = 'e', long = "end", help = "End date for the commits in YYYY-MM-DD format")]
     pub end: Option<String>,
 
     #[arg(
@@ -24,6 +24,13 @@ pub struct Args {
         help = "Show updated commit history after rewriting"
     )]
     pub show_history: bool,
+
+    #[arg(
+        short = 'p',
+        long = "pick-specific-commits",
+        help = "Pick specific commits to rewrite. Provide a comma-separated list of commit hashes."
+    )]
+    pub pic_specific_commits: bool,
 }
 
 impl Args {


### PR DESCRIPTION
This pull request updates the `Args` struct in `src/args.rs` to enhance usability by adding short flag options for existing arguments and introducing a new argument for selecting specific commits. These changes aim to improve the user experience when interacting with the command-line interface.

### Enhancements to argument usability:

* Added short flag options for existing arguments in the `Args` struct:
  - `name` now supports a short flag `-n`.
  - `start` (renamed to `begin`) now supports a short flag `-b`.
  - `end` now supports a short flag `-e`.

### New functionality:

* Introduced a new argument `pick-specific-commits` with a short flag `-p` to allow users to specify a comma-separated list of commit hashes for selective rewriting.