### PR TITLE
feat: combined get history and print history

### DIFF
--- a/src/rewrite/rewrite_all.rs
+++ b/src/rewrite/rewrite_all.rs
@@ -1,5 +1,5 @@
 use crate::utils::types::Result;
-use crate::{args::Args, utils::commit_history::print_updated_history};
+use crate::{args::Args, utils::commit_history::get_commit_history};
 use chrono::NaiveDateTime;
 use colored::Colorize;
 use git2::{Repository, Signature, Sort, Time};
@@ -63,7 +63,7 @@ pub fn rewrite_all_commits(args: &Args, timestamps: Vec<NaiveDateTime>) -> Resul
             new_head.to_string().cyan()
         );
         if args.show_history {
-            print_updated_history(args)?;
+            get_commit_history(args, true)?;
         }
     }
 

--- a/src/rewrite/rewrite_specific.rs
+++ b/src/rewrite/rewrite_specific.rs
@@ -1,7 +1,6 @@
-use crate::utils::commit_history::get_commit_history;
 use crate::utils::types::Result;
 use crate::utils::types::{CommitInfo, EditOptions};
-use crate::{args::Args, utils::commit_history::print_updated_history};
+use crate::{args::Args, utils::commit_history::get_commit_history};
 use chrono::NaiveDateTime;
 use colored::Colorize;
 use git2::{Repository, Signature, Sort, Time};
@@ -197,7 +196,7 @@ pub fn get_edit_options() -> Result<EditOptions> {
 }
 
 pub fn rewrite_specific_commits(args: &Args) -> Result<()> {
-    let commits = get_commit_history(args)?;
+    let commits = get_commit_history(args, false)?;
 
     if commits.is_empty() {
         println!("{}", "No commits found!".red());
@@ -264,7 +263,7 @@ pub fn rewrite_specific_commits(args: &Args) -> Result<()> {
     println!("\n{}", "✓ Commit successfully edited!".green().bold());
 
     if args.show_history {
-        print_updated_history(args)?;
+        get_commit_history(args, true)?;
     }
 
     Ok(())

--- a/src/utils/commit_history.rs
+++ b/src/utils/commit_history.rs
@@ -3,117 +3,16 @@ use crate::{args::Args, utils::types::CommitInfo};
 use colored::Colorize;
 use git2::{Repository, Sort};
 
-pub fn print_updated_history(args: &Args) -> Result<()> {
+pub fn get_commit_history(args: &Args, print: bool) -> Result<Vec<CommitInfo>> {
     let repo = Repository::open(args.repo_path.as_ref().unwrap())?;
 
     let mut revwalk = repo.revwalk()?;
     revwalk.push_head()?;
     revwalk.set_sorting(Sort::TOPOLOGICAL | Sort::TIME)?;
 
-    // Collect all commits first to calculate statistics
+    // Collect all commits first
     let mut commits = Vec::new();
-    let mut timestamps = Vec::new();
-
-    for oid_result in revwalk {
-        let oid = oid_result?;
-        let commit = repo.find_commit(oid)?;
-        let timestamp = commit.time();
-        let datetime = chrono::DateTime::from_timestamp(timestamp.seconds(), 0)
-            .unwrap_or_default()
-            .naive_utc();
-
-        commits.push((oid, commit));
-        timestamps.push(datetime);
-    }
-
-    // Calculate statistics
-    let total_commits = commits.len();
-    let (earliest_date, latest_date) = if !timestamps.is_empty() {
-        let mut sorted_timestamps = timestamps.clone();
-        sorted_timestamps.sort();
-        (
-            sorted_timestamps[0],
-            sorted_timestamps[sorted_timestamps.len() - 1],
-        )
-    } else {
-        return Ok(());
-    };
-
-    let date_span = latest_date.signed_duration_since(earliest_date).num_days();
-    let unique_authors: std::collections::HashSet<String> = commits
-        .iter()
-        .map(|(_, commit)| commit.author().name().unwrap_or("Unknown").to_string())
-        .collect();
-
-    // Print summary
-    println!("\n{}", "Updated Commit History Summary:".bold().green());
-    println!("{}", "-".repeat(60).cyan());
-    println!(
-        "{}: {}",
-        "Total Commits".bold(),
-        total_commits.to_string().yellow()
-    );
-    println!(
-        "{}: {} days",
-        "Date Span".bold(),
-        date_span.to_string().yellow()
-    );
-    println!(
-        "{}: {} to {}",
-        "Date Range".bold(),
-        earliest_date.format("%Y-%m-%d %H:%M:%S").to_string().blue(),
-        latest_date.format("%Y-%m-%d %H:%M:%S").to_string().blue()
-    );
-    println!(
-        "{}: {}",
-        "Unique Authors".bold(),
-        unique_authors.len().to_string().yellow()
-    );
-    if unique_authors.len() <= 5 {
-        println!(
-            "{}: {}",
-            "Authors".bold(),
-            unique_authors
-                .iter()
-                .cloned()
-                .collect::<Vec<_>>()
-                .join(", ")
-                .magenta()
-        );
-    }
-    println!("{}", "=".repeat(60).cyan());
-
-    // Print detailed commit history
-    println!("\n{}", "Detailed Commit History:".bold().green());
-    println!("{}", "-".repeat(60).cyan());
-
-    for (i, (oid, commit)) in commits.iter().enumerate() {
-        let short_hash = &oid.to_string()[..8];
-        let message = commit.message().unwrap_or("(no message)");
-        let author = commit.author();
-
-        println!(
-            "{} {} {} {}",
-            short_hash.yellow().bold(),
-            timestamps[i].format("%Y-%m-%d %H:%M:%S").to_string().blue(),
-            author.name().unwrap_or("Unknown").magenta(),
-            message.lines().next().unwrap_or("").white()
-        );
-    }
-
-    println!("{}", "=".repeat(60).cyan());
-
-    Ok(())
-}
-
-pub fn get_commit_history(args: &Args) -> Result<Vec<CommitInfo>> {
-    let repo = Repository::open(args.repo_path.as_ref().unwrap())?;
-
-    let mut revwalk = repo.revwalk()?;
-    revwalk.push_head()?;
-    revwalk.set_sorting(Sort::TOPOLOGICAL | Sort::TIME)?;
-
-    let mut commits = Vec::new();
+    let mut commit_infos = Vec::new();
 
     for oid_result in revwalk {
         let oid = oid_result?;
@@ -137,8 +36,87 @@ pub fn get_commit_history(args: &Args) -> Result<Vec<CommitInfo>> {
             parent_count: commit.parent_count(),
         };
 
-        commits.push(commit_info);
+        if print {
+            commits.push((oid, commit));
+        }
+        commit_infos.push(commit_info);
     }
 
-    Ok(commits)
+    // If print is true, calculate and display statistics
+    if print {
+        let total_commits = commit_infos.len();
+
+        if total_commits > 0 {
+            let timestamps: Vec<_> = commit_infos.iter().map(|c| c.timestamp).collect();
+            let mut sorted_timestamps = timestamps.clone();
+            sorted_timestamps.sort();
+
+            let earliest_date = sorted_timestamps[0];
+            let latest_date = sorted_timestamps[sorted_timestamps.len() - 1];
+            let date_span = latest_date.signed_duration_since(earliest_date).num_days();
+
+            let unique_authors: std::collections::HashSet<String> =
+                commit_infos.iter().map(|c| c.author_name.clone()).collect();
+
+            // Print summary
+            println!("\n{}", "Updated Commit History Summary:".bold().green());
+            println!("{}", "-".repeat(60).cyan());
+            println!(
+                "{}: {}",
+                "Total Commits".bold(),
+                total_commits.to_string().yellow()
+            );
+            println!(
+                "{}: {} days",
+                "Date Span".bold(),
+                date_span.to_string().yellow()
+            );
+            println!(
+                "{}: {} to {}",
+                "Date Range".bold(),
+                earliest_date.format("%Y-%m-%d %H:%M:%S").to_string().blue(),
+                latest_date.format("%Y-%m-%d %H:%M:%S").to_string().blue()
+            );
+            println!(
+                "{}: {}",
+                "Unique Authors".bold(),
+                unique_authors.len().to_string().yellow()
+            );
+            if unique_authors.len() <= 5 {
+                println!(
+                    "{}: {}",
+                    "Authors".bold(),
+                    unique_authors
+                        .iter()
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                        .magenta()
+                );
+            }
+            println!("{}", "=".repeat(60).cyan());
+
+            // Print detailed commit history
+            println!("\n{}", "Detailed Commit History:".bold().green());
+            println!("{}", "-".repeat(60).cyan());
+
+            for commit_info in &commit_infos {
+                println!(
+                    "{} {} {} {}",
+                    commit_info.short_hash.yellow().bold(),
+                    commit_info
+                        .timestamp
+                        .format("%Y-%m-%d %H:%M:%S")
+                        .to_string()
+                        .blue(),
+                    commit_info.author_name.magenta(),
+                    commit_info.message.lines().next().unwrap_or("").white()
+                );
+            }
+
+            println!("{}", "=".repeat(60).cyan());
+        }
+    }
+
+    Ok(commit_infos)
 }


### PR DESCRIPTION
This pull request refactors the commit history functionality by consolidating two functions (`print_updated_history` and `get_commit_history`) into a single, more versatile `get_commit_history` function. The changes improve code maintainability and flexibility by introducing a `print` parameter to control whether commit history details are printed or returned as a list of `CommitInfo` objects.

### Refactoring of commit history functionality:

* **Consolidation of functions**: The `print_updated_history` function has been removed, and its functionality has been merged into the `get_commit_history` function. The new `get_commit_history` function now accepts a `print` parameter to determine whether to print the commit history or return it as a list of `CommitInfo` objects. (`src/utils/commit_history.rs`, [[1]](diffhunk://#diff-866040324bec44e7f9922959e24a80beeea5e4eb19b43723efc99a1e5f5aede9L6-R15) [[2]](diffhunk://#diff-866040324bec44e7f9922959e24a80beeea5e4eb19b43723efc99a1e5f5aede9R25-R59) [[3]](diffhunk://#diff-866040324bec44e7f9922959e24a80beeea5e4eb19b43723efc99a1e5f5aede9L90-R121)

* **Code simplification in `rewrite_all.rs`**: Calls to `print_updated_history` have been replaced with calls to `get_commit_history` with the `print` parameter set to `true`. (`src/rewrite/rewrite_all.rs`, [[1]](diffhunk://#diff-b599a3a4d87e82dde4ecddaabc555776849b148080b672845446555e2154af59L2-R2) [[2]](diffhunk://#diff-b599a3a4d87e82dde4ecddaabc555776849b148080b672845446555e2154af59L66-R66)

* **Code simplification in `rewrite_specific.rs`**: Similarly, calls to `print_updated_history` have been replaced with `get_commit_history` with the `print` parameter set to `true`. Additionally, the function now retrieves commit history with `get_commit_history` using `print` set to `false` when only the data is needed. (`src/rewrite/rewrite_specific.rs`, [[1]](diffhunk://#diff-ea989224e4151340ceea911471799b46363dc927e7ba1145bb078a7b065fc8eaL1-R3) [[2]](diffhunk://#diff-ea989224e4151340ceea911471799b46363dc927e7ba1145bb078a7b065fc8eaL200-R199) [[3]](diffhunk://#diff-ea989224e4151340ceea911471799b46363dc927e7ba1145bb078a7b065fc8eaL267-R266)